### PR TITLE
Update changelog: Remove Thinkful offer

### DIFF
--- a/SDP-changelog.md
+++ b/SDP-changelog.md
@@ -3,6 +3,10 @@
 This changelog provides a way to track updates to the GitHub Student Developer Pack, including newly added or removed partner offers. Issues accessing particular offers will also be tracked via this changelog. For more details on particular offers, you can check the official GitHub Student Developer Pack page [here](https://education.github.com/pack) or the SDP FAQ and current partners list [here](https://github.com/github-education-resources/Student-Developer-Pack-Current-Partners-FAQ/tree/main).
 
 _________
+October 25, 2025
+### Paused
+Thinkful offer removed from SDP due to technical issue. 
+_________
 
 September 30, 2025
 ### Resumed


### PR DESCRIPTION
Removed Thinkful offer due to technical issue.